### PR TITLE
feat: add x-lookout-token to request header

### DIFF
--- a/lib/observer/http.js
+++ b/lib/observer/http.js
@@ -13,8 +13,10 @@ class HttpObserver extends Base {
     super();
     this.registry = registry;
     this.options = registry.options;
-    const { agentHost, agentPort } = this.options;
+    const { agentHost, agentPort, accessToken } = this.options;
     assert(agentHost && agentPort, '[HttpObserver] agentHost & agentPort are required');
+    // accessToken should not be empty
+    this.accessToken = accessToken || Buffer.from(clientIp).toString('base64');
     this.url = `http://${agentHost}:${agentPort}/datas`;
     this.httpclient = this.options.httpclient || require('urllib');
     this.reportDecider = new ReportDecider();
@@ -102,6 +104,8 @@ class HttpObserver extends Base {
     this.registry.counter(
       this.registry.createId('lookout.client.report.count').withTag('mtd', (options.method || 'get').toLowerCase())
     ).inc();
+    options.headers = options.headers || {};
+    options.headers['X-Lookout-Token'] = this.accessToken;
     this.httpclient.request(this.url, options, (err, data, res) => {
       if (err) {
         if (err.name.includes('TimeoutError')) {

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   "dependencies": {
     "address": "^1.0.3",
     "debug": "^3.1.0",
-    "sdk-base": "^3.4.0",
+    "sdk-base": "^3.5.0",
     "snappyjs": "^0.6.0",
-    "urllib": "^2.28.1",
-    "utility": "^1.13.1"
+    "urllib": "^2.29.1",
+    "utility": "^1.14.0"
   },
   "devDependencies": {
     "autod": "^3.0.1",
@@ -47,11 +47,11 @@
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.4",
     "contributors": "^0.5.1",
-    "egg-bin": "^4.7.0",
+    "egg-bin": "^4.8.3",
     "egg-ci": "^1.8.0",
-    "eslint": "^5.0.1",
-    "eslint-config-egg": "^7.0.0",
-    "mm": "^2.2.0",
+    "eslint": "^5.5.0",
+    "eslint-config-egg": "^7.1.0",
+    "mm": "^2.4.1",
     "mz-modules": "^2.1.0"
   },
   "engines": {

--- a/test/observer.test.js
+++ b/test/observer.test.js
@@ -56,6 +56,9 @@ describe('test/observer.test.js', () => {
     const server = http.createServer((req, res) => {
       const o = url.parse(req.url);
       console.log(req.method + ' ' + o.pathname);
+      console.log('X-Lookout-Token =====>', req.headers['x-lookout-token']);
+      assert(req.headers['x-lookout-token']);
+
       if (o.pathname === '/datas') {
         if (req.method === 'GET') {
           server.emit('healthCheck');


### PR DESCRIPTION
> X-Lookout-Token，它怎么生成。【lookout 需要关注】

> 第一阶段过渡时期，可以允许一些简单的随机字符串的，base64;
正式由 UserName:PassWD 进行base64得到token。 目的是，也兼容支持basic auth;
Passwd 或 UserName (包含用来表示 lookout 当前所以在环境的字符串后缀部分)。方便串用时排查问题；